### PR TITLE
Add a basic API implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+Start the server with `uvicorn server:app --reload`.
+
+POST conllu you want to work with at `/upload`.
+
+With the acquired id, GET `/stats/[id]` or `/rules/[id]` for stats or modified conllu respectively.
+
+Happy rule-based simplification :^)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,7 @@ colorama==0.4.6
 termcolor==2.4.0
 udapi @ git+https://github.com/udapi/udapi-python.git@a43cd21f962a72e4f5e6f5dc40c5d35393669107
 ufal.udpipe==1.3.1.1
+nltk==3.8.1
+fastapi==0.110.0
+uvicorn==0.29.0
+python-multipart==0.0.9

--- a/server.py
+++ b/server.py
@@ -1,0 +1,79 @@
+import os
+from math import log2
+from typing import Iterator, Tuple
+
+from fastapi import FastAPI, UploadFile, HTTPException
+from udapi.core.document import Document
+from udapi.core.node import Node
+
+import rules
+
+app = FastAPI()
+
+@app.get("/")
+def root():
+  return {"this is": "dog"}
+
+@app.post("/upload", status_code=201)
+def receive_conllu(file: UploadFile):
+  #read uploaded file
+  file_id = os.urandom(8).hex()
+  filename = file_id + ".conllu"
+  with open(filename, "wb") as local_copy:
+    local_copy.write(file.file.read())
+  try:
+    doc = Document(filename=filename)
+    return {"file_id": file_id}
+  except ValueError as e:
+    local_copy.close()
+    os.remove(filename)
+    raise HTTPException(status_code=406, detail=f"{type(e).__name__}: {str(e)}")
+
+@app.get("/stats/{text_id}")
+def get_stats_for_conllu(text_id: str):
+  #return statistics for a given id
+  doc = get_doc_from_id(text_id)
+  filtered_nodes = list(node for node in doc.nodes if node.upos != "PUNCT")
+  sentences = len(list(doc.trees))
+  words = len(filtered_nodes)
+  chars = sum(len(node.form) for node in filtered_nodes)
+  return {
+    "id": text_id,
+    "sents": sentences,
+    "words": words,
+    "chars": chars,
+    "CLI": 0.047 * (chars/words) * 100 - 0.286 * (sentences/words) * 100 - 12.9,
+    "ARI": 3.666 * (chars/words) + 0.631 * (words/sentences) - 19.491, #formula in Cinkova 2021 has parens switched
+    "num_hapax": count_hapaxes(filtered_nodes, use_lemma=True),
+    "entropy": compute_entropy(filtered_nodes, use_lemma=True)
+  }
+
+@app.get("/rules/{text_id}")
+def get_conllu_after_rules_applied(text_id: str):
+  #return modified conllu after application of rules
+  doc = get_doc_from_id(text_id)
+  rules.double_adpos_rule().run(doc)
+  return {"id": text_id, "document": doc.to_conllu_string()}
+
+def get_doc_from_id(id: str):
+  try:
+    doc = Document(filename=id + ".conllu")
+    return doc
+  except ValueError:
+    raise HTTPException(status_code=404)
+
+def get_word_counts(nodes: list[Node], use_lemma = False) -> Iterator[Tuple[str, int]]:
+  all_words = list(node.form if not use_lemma else node.lemma for node in nodes)
+  unique_words = set(all_words)
+  counts = map(lambda x: all_words.count(x), unique_words)
+  return zip(unique_words,counts)
+
+def count_hapaxes(nodes: list[Node], use_lemma = False):
+  counts = [item[1] for item in get_word_counts(nodes, use_lemma)]
+  return counts.count(1)
+
+def compute_entropy(nodes: list[Node], use_lemma = False):
+  counts = [item[1] for item in get_word_counts(nodes, use_lemma)]
+  n_words = sum(counts)
+  probs = map(lambda x: x/n_words, counts)
+  return -sum(prob * log2(prob) for prob in probs)

--- a/txt_conllu_conv.py
+++ b/txt_conllu_conv.py
@@ -1,36 +1,53 @@
 #!/usr/bin/env python3
 
 from ufal.udpipe import Model, Pipeline
+from argparse import ArgumentParser
 
 import sys
 import os
 
 if __name__ == "__main__":
     # TODO: unhardcodify
-    model = Model.load("_local/czech-pdt-ud-2.5-191206.udpipe")
-    pipeline = Pipeline(model, "tokenize", Pipeline.DEFAULT, Pipeline.DEFAULT, "conllu")
+    parser = ArgumentParser(prog='UDPipe Rules: Conllu Conversion',
+                            description='Converts specified files to conllu format (or potentially others).',
+                            )
+    parser.add_argument('-m', '--model', help='Location of the model.', required=True)
+    parser.add_argument('-c', '--conllu', default='conllu', help='Location of the conllu folder. Defaults to \'conllu\'.')
+    parser.add_argument('-f', '--format', default='conllu', help='Specify the output format. Defaults to \'conllu\'')
+    parser.add_argument('filename', nargs='*', help='Name of the file to process. '
+                                                    'Can be specified multiple times. Defaults to stdin')
+    args = parser.parse_args()
 
-    if len(sys.argv) > 1:
-        for arg in sys.argv[1:]:
-            with open(arg, "r") as input_fs:
-                counter = 1
-                for line in input_fs:
-                    if line.strip(" \n") == "":
-                        continue
+    conllu_location = args.conllu
+    output_format = args.format
+    model = Model.load(args.model)
+    pipeline = Pipeline(model, "tokenize", Pipeline.DEFAULT, Pipeline.DEFAULT, output_format)
+    
 
-                    npath = os.path.join(
-                        "conllu", os.path.splitext(arg)[0] + f"_{counter}.conllu"
-                    )
-                    if not os.path.isdir(dir := os.path.dirname(npath)):
-                        os.makedirs(dir)
-                    print(f"> {npath}", file=sys.stderr)
-
-                    with open(npath, "w+") as output_fs:
-                        print(pipeline.process(line), file=output_fs)
-
-                    counter += 1
-    else:
+    if len(args.filename) == 0:
+        #read from stdin
         string = ""
         for line in sys.stdin:
             string = " ".join([string, line])
         print(pipeline.process(string))
+        exit(0)
+
+    for filename in args.filename:
+        #read files from cmdline
+        with open(filename, "r") as input_fs:
+            counter = 1
+            for line in input_fs:
+                if line.strip(" \n") == "":
+                    continue
+
+                npath = os.path.join(
+                    conllu_location, os.path.splitext(filename)[0] + f"_{counter}.{output_format}"
+                )
+                if not os.path.isdir(dir := os.path.dirname(npath)):
+                    os.makedirs(dir)
+                print(f"> {npath}", file=sys.stderr)
+
+                with open(npath, "w+") as output_fs:
+                    print(pipeline.process(line), file=output_fs)
+
+                counter += 1


### PR DESCRIPTION
A very basic implementation of the API for PONK-rules. Supports `conllu` uploads via `/upload` and querying for basic statistical properties of the text via `/stats/[id]` and rule-based modifications via `/rules/[id]`.

Notably missing are some syllable-based metrics as we have not yet agreed which segmentation method to use.

We are also missing caching and deletion of stale files.

Furthermore, the user has no control over which rules to apply and which stats to retrieve. All of this should be implemented soon.

Likewise, we are missing tests for the code, but as there is still very little code to test, this is likely not a top priority.

Also included is a slightly improved conllu parser, because I didn't feel like splitting it into a separate PR. Sorry.