### PR TITLE
Refactor rules and metrics; add a sketch of parsing

### DIFF
--- a/metrics.py
+++ b/metrics.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+from udapi.core.document import Document
+
+from typing import Iterator, Tuple, Callable
+
+from math import log2
+
+
+class Metric:
+    def __init__(self, doc: Document):
+        self.doc = doc
+
+    def apply(self) -> int:
+        raise NotImplementedError("Please define your metric")
+
+    @staticmethod
+    def id():
+        raise NotImplementedError("Please give your metric an id")
+
+    def get_word_counts(self, use_lemma=False) -> Iterator[Tuple[str, int]]:
+        all_words = list(node.form if not use_lemma else node.lemma for node in self.doc.nodes)
+        unique_words = set(all_words)
+        counts = map(lambda x: all_words.count(x), unique_words)
+        return zip(unique_words, counts)
+
+    @staticmethod
+    def get_metrics() -> dict[str, type]:
+        return {sub.id(): sub for sub in Metric.__subclasses__()}
+
+    @staticmethod
+    def build_from_string(string: str) -> Callable[[Document], Metric]:
+        metric_id, args = string.split(':')[0], string.split(':')[1:]
+        args = {arg.split('=')[0]: arg.split('=')[1:] for arg in args}
+        return lambda x: Metric.get_metrics()[metric_id](doc=x, **args)
+
+
+class HapaxCount(Metric):
+    def __init__(self, doc: Document, use_lemma="True"):
+        Metric.__init__(self, doc)
+        self.use_lemma = use_lemma == "True"
+
+    def apply(self) -> int:
+        counts = [item[1] for item in super().get_word_counts(self.use_lemma)]
+        return counts.count(1)
+
+    @staticmethod
+    def id():
+        return "num_hapax"
+
+
+class Entropy(Metric):
+    def __init__(self, doc: Document, use_lemma="True"):
+        Metric.__init__(self, doc)
+        self.use_lemma = use_lemma == "True"
+
+    def apply(self) -> int:
+        counts = [item[1] for item in self.get_word_counts(self.use_lemma)]
+        n_words = sum(counts)
+        probs = map(lambda x: x/n_words, counts)
+        return -sum(prob * log2(prob) for prob in probs)
+
+    @staticmethod
+    def id():
+        return "entropy"


### PR DESCRIPTION
Rules have been moved into a separate file and turned into classes. In the long run, we might need the client to pick which metrics they want to have computed, and giving each metric a string representation is a step towards that.

Currently, the system is a bit convoluted, it could make sense to make use of UDAPI's block system for this instead. I will sleep on this and report back. 