### PR TITLE
Rules

### DIFF
--- a/rules.py
+++ b/rules.py
@@ -85,3 +85,19 @@ class double_adpos_rule(Rule):
     def after_process_document(self, document):
         for root in self.modified_roots:
             root.text = root.compute_text()
+
+class passive_rule(Rule):
+    @StringBuildable.parse_string_args(detect_only=bool)
+    def __init__(self, detect_only=True):
+        Rule.__init__(self, detect_only)
+
+    @classmethod
+    def id(cls):
+        return 'rule_passive'
+    
+    def process_node(self, node):
+        if node.deprel == 'aux:pass':
+            parent = node.parent
+
+            self.annotate_node(node, 'aux')
+            self.annotate_node(parent, 'participle')

--- a/rules.py
+++ b/rules.py
@@ -11,10 +11,6 @@ from utils import StringBuildable
 import os
 
 
-# TODO: unify rule intervention marks
-# TODO: generalize rule blocks (e.g. using an abstract-ish class). it could contain process_id generation, text recomputation etc.
-
-
 class Rule(Block, StringBuildable):
     def __init__(self, detect_only=True, **kwargs):
         Block.__init__(self, **kwargs)
@@ -44,26 +40,23 @@ class double_adpos_rule(Rule):
         # TODO: sometimes the structure isn't actually ambiguous and doesn't need to be ammended
         # TODO: sometimes the rule catches adpositions that shouldn't be repeated in the coordination
 
-
         if node.upos != "CCONJ":
-            return None #nothing we can do for this node, bail
+            return None  # nothing we can do for this node, bail
 
         cconj = node
 
         # find an adposition present in the coordination
         for parent_adpos in [
-            nd
-            for nd in cconj.parent.siblings
-            if nd.udeprel == "case" and nd.upos == "ADP"
+            nd for nd in cconj.parent.siblings if nd.udeprel == "case" and nd.upos == "ADP"
         ]:
             # check that the two coordination elements have the same case
             if cconj.parent.feats["Case"] != parent_adpos.parent.feats["Case"]:
                 continue
 
             # check that the second coordination element doesn't already have an adposition
-            if not [
-                nd for nd in cconj.siblings if nd.lemma == parent_adpos.lemma
-            ] and not [nd for nd in cconj.siblings if nd.upos == "ADP"]:
+            if not [nd for nd in cconj.siblings if nd.lemma == parent_adpos.lemma] and not [
+                nd for nd in cconj.siblings if nd.upos == "ADP"
+            ]:
                 if not self.detect_only:
                     correction = util.clone_node(
                         parent_adpos,
@@ -86,6 +79,7 @@ class double_adpos_rule(Rule):
         for root in self.modified_roots:
             root.text = root.compute_text()
 
+
 class passive_rule(Rule):
     @StringBuildable.parse_string_args(detect_only=bool)
     def __init__(self, detect_only=True):
@@ -94,10 +88,40 @@ class passive_rule(Rule):
     @classmethod
     def id(cls):
         return 'rule_passive'
-    
+
     def process_node(self, node):
         if node.deprel == 'aux:pass':
             parent = node.parent
 
             self.annotate_node(node, 'aux')
             self.annotate_node(parent, 'participle')
+
+
+class pred_subj_distance_rule(Rule):
+    @StringBuildable.parse_string_args(detect_only=bool)
+    def __init__(self, detect_only=True, max_distance=6):
+        Rule.__init__(self, detect_only)
+        self.max_distance = max_distance
+
+    @classmethod
+    def id(cls):
+        return 'rule_pred_subj_distance'
+
+    def process_node(self, node):
+        # locate subject
+        if node.udeprel in ('nsubj', 'csubj'):
+
+            # locate predicate
+            pred = node.parent
+
+            # if the predicate is analytic, select the (non-conditional) auxiliary or the copula
+            if finite_verbs := [
+                nd
+                for nd in pred.children
+                if nd.udeprel == 'cop' or (nd.udeprel == 'aux' and nd.feats['Mood'] != 'Cnd')
+            ]:
+                pred = finite_verbs[0]
+
+            if abs(node.ord - pred.ord) > self.max_distance:
+                self.annotate_node(pred, 'predicate_grammar')
+                self.annotate_node(node, 'subject')


### PR DESCRIPTION
Rules for passive voice detection and too spaced-out predicate-subject pairs detections were added. The latter often clashes with incorrect UDPipe parsing.